### PR TITLE
fix for Dockerfile: append second env var instead of replace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN install2.r \
       ropensci-review-tools/roreviewapi
 
 RUN echo "GITHUB_TOKEN='<my_github_token>'" > ~/.Renviron \
-    && echo "GITHUB_PAT='<my_github_token>'" > ~/.Renviron \
-RUN git config --global user.name "username" \
+    && echo "GITHUB_PAT='<my_github_token>'" >> ~/.Renviron \
+    && git config --global user.name "username" \
     && git config --global user.email "my.address@mail.com"
 
 EXPOSE 8000


### PR DESCRIPTION
hi @mpadge 

the original version of this file uses replace `>` for both env vars, so the first env var set is replaced by the second. changed it to replace, then append. The API wasn't working until this fix. 

See any issues with this?