### PR TITLE
use escaped double quotes in roreviewapi::serve_api call in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN echo "GITHUB_TOKEN='<my_github_token>'" > ~/.Renviron \
 
 EXPOSE 8000
 
-RUN echo "#!/bin/bash\nRscript -e 'roreviewapi::serve_api(port=8000L,os='ubuntu',os_release='20.04')'" > /server_api.sh \
+RUN echo "#!/bin/bash\nRscript -e 'roreviewapi::serve_api(port=8000L,os=\"ubuntu\",os_release=\"20.04\")'" > /server_api.sh \
   && chmod a+x /server_api.sh
 
 CMD /server_api.sh


### PR DESCRIPTION
addresses in part #4 

single quotes used were lost on result of `echo`, i think because single quotes within single quotes maybe