### PR TITLE
feat: use gitcreds that will fall back to the environment variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,6 +18,7 @@ Imports:
     fs,
     gert,
     ghql,
+    gitcreds,
     here,
     httr,
     jsonlite,

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,7 +21,7 @@ symbol_crs <- function () {
 #' @noRd
 get_github_user <- function () {
 
-    gh_tok <- gitcreds::gitcreds_get ()
+    gh_tok <- gitcreds::gitcreds_get ()$password
 
     # Check corresponding user name:
     u <- "https://api.github.com/user"

--- a/R/utils.R
+++ b/R/utils.R
@@ -21,7 +21,7 @@ symbol_crs <- function () {
 #' @noRd
 get_github_user <- function () {
 
-    gh_tok <- Sys.getenv ("GITHUB_TOKEN")
+    gh_tok <- gitcreds::gitcreds_get ()
 
     # Check corresponding user name:
     u <- "https://api.github.com/user"


### PR DESCRIPTION
Fix #53

See https://gitcreds.r-lib.org/reference/gitcreds_get.html?q=GITHUB_TOKEN#migrating-from-the-github-pat-environment-variable and https://github.com/r-lib/gitcreds/blob/6d0cc82124f8acebc15d855550423481b0848c4c/tests/testthat/test-cache.R#L49